### PR TITLE
refactor: avoiding FPs and speed up

### DIFF
--- a/dotnet/msil_suspicious_use_of_strreverse.yar
+++ b/dotnet/msil_suspicious_use_of_strreverse.yar
@@ -8,15 +8,18 @@ rule msil_suspicious_use_of_strreverse {
         */
         description = "Detects mixed use of Microsoft.CSharp and VisualBasic to use StrReverse"
         author = "dr4k0nia"
-        version = "1.0"
+        version = "1.1"
         date = "01/31/2023"
+        modified = "02/22/2023"
         hash = "02ce0980427dea835fc9d9eed025dd26672bf2c15f0b10486ff8107ce3950701"
     strings:
         $csharp = "Microsoft.CSharp"
         $vbnet = "Microsoft.VisualBasic"
         $strreverse = "StrReverse"
     condition:
-        dotnet.is_dotnet
+        uint16(0) == 0x5a4d
+        and dotnet.is_dotnet
+        and filesize < 50MB
         and $csharp
         and $vbnet
         and $strreverse


### PR DESCRIPTION
- there are some FPs with larger files; all malicious files have a smaller file size
- adding the magic header check speeds up the scan process (shortcut eval)
- I'll used the rule in my repo in a slightly modified form and avoid the dotnet module completely, because loading it already consumes CPU cycles

![Screenshot 2023-02-22 at 15 34 04](https://user-images.githubusercontent.com/2851492/220654234-c53c61b0-dd22-4203-8cab-038bde15dd36.png)
